### PR TITLE
Fix: [client/init] get a new version of the access_token

### DIFF
--- a/dingtalk/__init__.py
+++ b/dingtalk/__init__.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 
-from dingtalk.client import SecretClient  # NOQA
+from dingtalk.client import SecretClient, AppKeyClient  # NOQA
 from dingtalk.client.isv import ISVClient  # NOQA
 from dingtalk.core.exceptions import DingTalkClientException, DingTalkException  # NOQA
 

--- a/dingtalk/client/__init__.py
+++ b/dingtalk/client/__init__.py
@@ -117,3 +117,19 @@ class SecretClient(DingTalkClient):
             '/gettoken',
             params={'corpid': self.corp_id, 'corpsecret': self.corp_secret}
         )
+
+
+class AppKeyClient(DingTalkClient):
+
+    def __init__(self, corp_id, app_key, app_secret, token=None, aes_key=None, storage=None, timeout=None, auto_retry=True):
+        super(AppKeyClient, self).__init__(corp_id, 'secret:'+corp_id, storage, timeout, auto_retry)
+        self.app_key = app_key
+        self.app_secret = app_secret
+        self.crypto = DingTalkCrypto(token, aes_key, corp_id)
+
+    def get_access_token(self):
+        return self._request(
+            'GET',
+            '/gettoken',
+            params={'appkey': self.app_key, 'appsecret': self.app_secret}
+        )


### PR DESCRIPTION
Compatible with new version, read access token through appkey and appsecret