### PR TITLE
消息接口发送消息的更改

### DIFF
--- a/dingtalk/client/api/message.py
+++ b/dingtalk/client/api/message.py
@@ -82,10 +82,13 @@ class Message(DingTalkBaseAPI):
         toparty = "|".join(map(to_text, toparty_list))
         if isinstance(msg_body, BodyBase):
             msg_body = msg_body.get_dict()
-        msg_body['touser'] = touser
-        msg_body['toparty'] = toparty
-        msg_body['agentid'] = agentid
-        return self._post('/message/send', msg_body)
+        body = {}
+        body["text"] = {"content":msg_body}
+        body['msgtype']="text"
+        body['touser'] = touser
+        body['toparty'] = toparty
+        body['agentid'] = agentid
+        return self._post('/message/send', body)
 
     def list_message_status(self, message_id):
         """


### PR DESCRIPTION
`def send(self, agentid, msg_body, touser_list=(), toparty_list=()):
        """
        发送企业通知消息

        :param agentid: 企业应用id，这个值代表以哪个应用的名义发送消息
        :param msg_body: BodyBase 消息体
        :param touser_list: 员工id列表
        :param toparty_list: 部门id列表
        :return:
        """

        touser = "|".join(map(to_text, touser_list))
        toparty = "|".join(map(to_text, toparty_list))
        if isinstance(msg_body, BodyBase):
            msg_body = msg_body.get_dict()
        body = {}
        body["text"] = {"content":msg_body}
        body['msgtype']="text"
        body['touser'] = touser
        body['toparty'] = toparty
        body['agentid'] = agentid
        return self._post('/message/send', body)`


s = client.message.send(agentid=agentId,msg_body=“msgbody”,touser_list={touser_list},toparty_list=[toparty_list])

这样只需传入一个msg主体