### PR TITLE
希望能认真验证.

### DIFF
--- a/dingtalk/client/api/message.py
+++ b/dingtalk/client/api/message.py
@@ -162,7 +162,7 @@ class Message(DingTalkBaseAPI):
             dept_id_list = None
 
         if not (userid_list or dept_id_list):
-            raise(ArgumentError('userid_list和dept_id_list不能同时为空。'))
+            raise(ArgumentError('userid_list和dept_id_list不能同时传递。'))
 
         if isinstance(msg_body, BodyBase):
             msg_body = msg_body.get_dict()

--- a/dingtalk/client/api/message.py
+++ b/dingtalk/client/api/message.py
@@ -113,8 +113,8 @@ class Message(DingTalkBaseAPI):
 
     def asyncsend(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=False):
         """
-        企业会话消息异步发送
-
+        企业会话消息异步发送(此API已不能使用, 请使用asyncsend_v2替换.)
+		
         :param msg_body: BodyBase 消息体
         :param agent_id: 微应用的id
         :param userid_list: 接收者的用户userid列表
@@ -122,6 +122,7 @@ class Message(DingTalkBaseAPI):
         :param to_all_user: 是否发送给企业全部用户
         :return: 任务id
         """
+        raise(RuntimeError('asyncsend已被废弃。后续版本将移除。 请使用asyncsend_v2替换。'))
         userid_list = ",".join(map(to_text, userid_list))
         dept_id_list = ",".join(map(to_text, dept_id_list))
 
@@ -142,7 +143,7 @@ class Message(DingTalkBaseAPI):
             result_processor=lambda x: x['task_id']
         )
 
-    def asyncsend_v2(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=False):
+    def asyncsend_v2(self, msg_body, agent_id, userid_list=[], dept_id_list=[], to_all_user=False):
         """
         企业会话消息异步发送
 
@@ -159,6 +160,9 @@ class Message(DingTalkBaseAPI):
             userid_list = None
         if not dept_id_list:
             dept_id_list = None
+        if not to_all_user:
+            to_all_user=None
+
         if isinstance(msg_body, BodyBase):
             msg_body = msg_body.get_dict()
         return self._top_request(

--- a/dingtalk/client/api/message.py
+++ b/dingtalk/client/api/message.py
@@ -143,7 +143,7 @@ class Message(DingTalkBaseAPI):
             result_processor=lambda x: x['task_id']
         )
 
-    def asyncsend_v2(self, msg_body, agent_id, userid_list=[], dept_id_list=[], to_all_user=False):
+    def asyncsend_v2(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=False):
         """
         企业会话消息异步发送
 
@@ -160,8 +160,9 @@ class Message(DingTalkBaseAPI):
             userid_list = None
         if not dept_id_list:
             dept_id_list = None
-        if not to_all_user:
-            to_all_user=None
+
+        if not (userid_list or dept_id_list):
+            raise(ArgumentError('userid_list和dept_id_list不能同时为空。'))
 
         if isinstance(msg_body, BodyBase):
             msg_body = msg_body.get_dict()

--- a/dingtalk/client/api/message.py
+++ b/dingtalk/client/api/message.py
@@ -111,7 +111,7 @@ class Message(DingTalkBaseAPI):
         msg_body['code'] = code
         return self._post('/message/sendByCode', msg_body)
 
-    def asyncsend(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=False):
+    def asyncsend(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=None):
         """
         企业会话消息异步发送(此API已不能使用, 请使用asyncsend_v2替换.)
 		
@@ -143,7 +143,7 @@ class Message(DingTalkBaseAPI):
             result_processor=lambda x: x['task_id']
         )
 
-    def asyncsend_v2(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=False):
+    def asyncsend_v2(self, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=None):
         """
         企业会话消息异步发送
 
@@ -218,7 +218,7 @@ class Message(DingTalkBaseAPI):
             result_processor=lambda x: x['send_result']
         )
 
-    def asyncsendbycode(self, code, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=False):
+    def asyncsendbycode(self, code, msg_body, agent_id, userid_list=(), dept_id_list=(), to_all_user=None):
         """
         通过用户授权码异步向企业会话发送消息
 


### PR DESCRIPTION
调用环境为 python 3.6, Ubuntu Linux 18.04
work_message.asyncsend_v2(TextBody('some text'), agent_id, userid_list=(userid, ))

以上调用没有给to_al_user值, to_all_user的值为缺少值False, 当如下代码会将 to_all_user也传给 http 请求，而接口中因为已经有了 userid_list, 那么会出现调用错误，这两个参数不能同时传递，因而报错。将缺省值改为None以后，则下列代码就不会传递to_all_user, 而能正确调用。
            optionaldict({
                "msg": msg_body,
                'agent_id': agent_id,
                'userid_list': userid_list,
                'dept_id_list': dept_id_list,
                'to_all_user': to_all_user  
            }),
