### PR TITLE
fix(message): Invalid arguments:to_all_user

### DIFF
--- a/dingtalk/client/api/message.py
+++ b/dingtalk/client/api/message.py
@@ -170,7 +170,7 @@ class Message(DingTalkBaseAPI):
                 'agent_id': agent_id,
                 'userid_list': userid_list,
                 'dept_id_list': dept_id_list,
-                'to_all_user': to_all_user
+                'to_all_user': 'true' if to_all_user else 'false'
             }),
             result_processor=lambda x: x['task_id']
         )


### PR DESCRIPTION
asyncsend_v2 接口报错：
Error code: 41, message: Invalid arguments:to_all_user

这个问题之前有人提过，但是我看 master 分支也未做修改，并且之前那位的解决方法是不正确的。